### PR TITLE
Add back regular blueberry jam

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -104,6 +104,14 @@ local canned_food_definitions = {
 		sugar = false,
 		transforms = "Pickled wild onions"
 	},
+	blueberry_jam = {
+		proper_name = "Blueberry jam",
+		found_in = "farming",
+		obj_name = "farming:blueberries",
+		orig_nutritional_value = 1,
+		amount = 6,
+		sugar = true
+	},
 	blackberry_jam = {
 		proper_name = "Blackberry jam",
 		found_in = "farming",


### PR DESCRIPTION
Commit https://github.com/h-v-smacker/canned_food/commit/889373fed770a8328688baa5bc064dbbeaad0654 removed "regular" blueberry jam, making `canned_food:blueberry_jam` an unknown item. I'm not sure if this was intentional, seeing as the texture was not removed, but I think it should be added back in.