### PR TITLE
Modernize mod.conf

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,6 +1,0 @@
-default
-vessels
-flowers
-ethereal?
-farming?
-unified_inventory?


### PR DESCRIPTION
Just remove warning about deprecated depends.txt
just for modern minetest servers
old minetest server may lose ability to load this mod but I still do the PR, idk